### PR TITLE
Changed TextInput to Label

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,7 @@ pub struct HRViewer {
     window: nwg::Window,
     layout: nwg::GridLayout,
     font: nwg::Font,
-    hr: nwg::TextInput,
+    hr: nwg::Label,
 }
 
 impl HRViewer {
@@ -71,7 +71,7 @@ mod basic_app_ui {
                 .flags(WS_POPUP | WS_VISIBLE)
                 .size((100, 100))
                 //TODO: figure out how to not hardcode this
-                .position((1820, 1100))
+                .position((0, 0))
                 .build()?;
 
             nwg::Font::builder()
@@ -80,14 +80,13 @@ mod basic_app_ui {
                 .weight(700)
                 .build(&mut data.font)?;
 
-            nwg::TextInput::builder()
+            nwg::Label::builder()
                 .text("--")
                 .size((100, 120))
                 .parent(&data.window)
                 .font(Some(&data.font))
-                .align(HTextAlign::Right)
+                .h_align(HTextAlign::Right)
                 .background_color(Some([255, 0, 0]))
-                .readonly(true)
                 .build(&mut data.hr)?;
 
             nwg::ControlBase::build_timer()


### PR DESCRIPTION
This text input should be changed to a label. Labels are read-only by default and can not be clicked on. The implementation is (generally) the same for Text input and the Label.

Selecting text in the Text Input field.
![The issue image](https://user-images.githubusercontent.com/10782090/103599771-c7ecca80-4eba-11eb-888c-fdea876b89f2.png)


Also changed the position to 0,0 as a placeholder instead of deriving a window height and width.